### PR TITLE
docs: add update instructions for home-manager users

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Add to your home-manager configuration:
 }
 ```
 
+To update opencode to the latest version (the flake.lock is auto-updated daily):
+
+```bash
+nix flake update oc
+```
+
 ## Related
 
 - [OpenCode Documentation](https://opencode.ai/docs/)


### PR DESCRIPTION
## Summary
- Added instructions for home-manager users to update opencode using `nix flake update oc`
- Notes that the flake.lock is auto-updated daily via GitHub workflow