### PR TITLE
docs: add JUSPAY_API_KEY setup note for Juspay users

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ nix run github:juspay/oc
 
 ## Juspay Configuration
 
+> [!NOTE]
+> For Juspay people: `JUSPAY_API_KEY` needs to be set and can be created at https://grid.ai.juspay.net/dashboard (requires VPN).
+
 Run with Juspay-specific LiteLLM configuration:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a GitHub-style NOTE callout in README for Juspay users explaining how to set up `JUSPAY_API_KEY`