### PR TITLE
fix(ci): use squash merge for flake update PRs

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -19,14 +19,15 @@ jobs:
       - uses: DeterminateSystems/update-flake-lock@main
         id: update
         with:
-          pr-title: "flake: update inputs"
+          pr-title: "chore(flake): update inputs"
+          commit-msg: "chore(flake): update inputs"
           pr-labels: dependencies
           pr-assignees: ${{ github.repository_owner }}
 
       - name: Enable auto-merge
         if: steps.update.outputs.pull-request-number != ''
         run: |
-          gh pr merge --auto --merge "${{ steps.update.outputs.pull-request-number }}"
+          gh pr merge --auto --squash "${{ steps.update.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- Changed `gh pr merge --auto --merge` to `gh pr merge --auto --squash` to comply with repository merge policy (no merge commits allowed)