### PR TITLE
Add Claude Code with Juspay config and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 One-click coding agents with Juspay's LLM configuration.
 
-Currently supports **[OpenCode](https://opencode.ai/)** only. Skills are sourced from [juspay/skills](https://github.com/juspay/skills).
+Supports **[Claude Code](https://code.claude.com/)** and **[OpenCode](https://opencode.ai/)**. Skills are sourced from [juspay/skills](https://github.com/juspay/skills).
 
 <figure>
 <img alt="OpenCode demo: variant selector, oneclick, and hello world prompt" src="demo/demo.gif" />
@@ -24,16 +24,17 @@ This launches an interactive selector. Or run a specific variant directly:
 
 | Variant | Command | Description |
 |---|---|---|
-| `opencode-juspay-oneclick` | `nix run github:juspay/AI#opencode-juspay-oneclick` | Juspay config and skills bundled |
-| `opencode-oneclick` | `nix run github:juspay/AI#opencode-oneclick` | Skills bundled, bring your own provider (e.g. Claude Max) |
+| `claude-code-juspay-oneclick` | `nix run github:juspay/AI#claude-code-juspay-oneclick` | Claude Code with Juspay config and skills |
+| `opencode-juspay-oneclick` | `nix run github:juspay/AI#opencode-juspay-oneclick` | OpenCode with Juspay config and skills |
+| `opencode-oneclick` | `nix run github:juspay/AI#opencode-oneclick` | OpenCode with skills, bring your own provider (e.g. Claude Max) |
 | `opencode-juspay-editable` | `nix run github:juspay/AI#opencode-juspay-editable` | Creates editable Juspay config at `~/.config/opencode/opencode.json` ([customize](https://opencode.ai/docs/config/)) |
 | `opencode` | `nix run github:juspay/AI#opencode` | Plain OpenCode, no config |
 
-The `JUSPAY_API_KEY` environment variable must be set when running the `opencode-juspay-*` variants.
+The `JUSPAY_API_KEY` environment variable must be set when running the `*-juspay-*` variants.
 
 ### Daily Updates
 
-This flake's `flake.lock` is **auto-updated daily** via CI, so you always get the latest OpenCode release and skills. If pinning via `flake.lock` in your own flake, run `nix flake update AI` to pull the latest.
+This flake's `flake.lock` is **auto-updated daily** via CI, so you always get the latest releases and skills. If pinning via `flake.lock` in your own flake, run `nix flake update AI` to pull the latest.
 
 ## Tips
 
@@ -72,7 +73,8 @@ Project instructions live in `agent/.apm/instructions/` and deploy to `.claude/r
 ```
 ├── agent/                    # APM local package (project instructions, mod.just)
 ├── coding-agents/
-│   └── opencode/             # OpenCode packages, settings, tests
+│   ├── claude-code/           # Claude Code packages
+│   └── opencode/              # OpenCode packages, settings, tests
 ├── demo/                     # Demo screencast infrastructure
 ```
 
@@ -81,6 +83,7 @@ Skills live in [juspay/skills](https://github.com/juspay/skills) and are pulled 
 ## Related
 
 - [juspay/skills](https://github.com/juspay/skills) — Shared AI agent skills (also usable via [APM](https://microsoft.github.io/apm/))
+- [Claude Code](https://code.claude.com/) — Anthropic's CLI coding agent
 - [OpenCode Documentation](https://opencode.ai/docs/) — Full docs on usage, configuration, and providers
 - [OpenCode GitHub](https://github.com/anomalyco/opencode) — The upstream OpenCode project
 - [llm-agents.nix](https://github.com/numtide/llm-agents.nix) — The upstream Nix packaging that this flake builds on

--- a/coding-agents/claude-code/juspay-oneclick.nix
+++ b/coding-agents/claude-code/juspay-oneclick.nix
@@ -1,0 +1,35 @@
+{ pkgs, lib, claude-code, skillsSrc }:
+let
+  sharedLib = import ../lib.nix;
+  skillsDir = pkgs.runCommand "claude-skills" { } ''
+    mkdir -p $out/.claude
+    ln -s ${skillsSrc}/skills $out/.claude/skills
+  '';
+in
+pkgs.writeShellApplication {
+  name = "claude";
+  text = ''
+    ${sharedLib.checkApiKey}
+    export ANTHROPIC_AUTH_TOKEN="''${JUSPAY_API_KEY:-}"
+    export ANTHROPIC_BASE_URL="https://grid.ai.juspay.net/"
+    export ANTHROPIC_MODEL="glm-latest"
+    export ANTHROPIC_SMALL_FAST_MODEL="glm-latest"
+    export CLAUDE_CODE_SUBAGENT_MODEL="glm-latest"
+    export ANTHROPIC_DEFAULT_SONNET_MODEL="glm-latest"
+    export ANTHROPIC_DEFAULT_OPUS_MODEL="glm-latest"
+    export ANTHROPIC_DEFAULT_HAIKU_MODEL="glm-latest"
+    export DISABLE_INTERLEAVED_THINKING=true
+    export API_TIMEOUT_MS=600000
+    export BASH_MAX_TIMEOUT_MS=300000
+    export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
+    # Unset conflicting Google/Vertex credentials
+    export GEMINI_API_KEY=""
+    export GOOGLE_CLOUD_PROJECT=""
+    export GOOGLE_APPLICATION_CREDENTIALS=""
+    export CLAUDE_CODE_USE_VERTEX=""
+    export CLOUD_ML_REGION=""
+    export GOOGLE_VERTEX_PROJECT=""
+    export ANTHROPIC_VERTEX_PROJECT_ID=""
+    exec ${lib.getExe claude-code} --add-dir ${skillsDir} "$@"
+  '';
+}

--- a/coding-agents/lib.nix
+++ b/coding-agents/lib.nix
@@ -1,0 +1,25 @@
+{
+  # Checks for JUSPAY_API_KEY, skipping for --version/--help.
+  # Uses ${..:-} for nounset (set -u) compatibility.
+  checkApiKey = ''
+    case " $* " in
+      *" --version "* | *" --help "* | *" -v "* | *" -h "*) ;;
+      *)
+        if [ -z "''${JUSPAY_API_KEY:-}" ]; then
+          cat >&2 <<'ERR'
+
+      Error: JUSPAY_API_KEY environment variable is not set.
+
+      Create an API key at: https://grid.ai.juspay.net/dashboard
+      (Requires Juspay VPN to access the dashboard)
+
+      Then run:
+        export JUSPAY_API_KEY=your-api-key
+
+    ERR
+          exit 1
+        fi
+        ;;
+    esac
+  '';
+}

--- a/coding-agents/opencode/packages/default.nix
+++ b/coding-agents/opencode/packages/default.nix
@@ -1,20 +1,22 @@
-{ pkgs, lib, opencode, opencode-juspay-editable, opencode-juspay-oneclick, opencode-oneclick }:
+{ pkgs, lib, opencode, opencode-juspay-editable, opencode-juspay-oneclick, opencode-oneclick, claude-code-juspay-oneclick }:
 pkgs.writeShellApplication {
   name = "opencode";
   runtimeInputs = [ pkgs.gum ];
   text = ''
-    choice=$(gum choose --header "Choose OpenCode variant:" \
-      "opencode-juspay-oneclick  — Juspay config and skills bundled" \
-      "opencode-oneclick         — Skills bundled, bring your own provider" \
-      "opencode-juspay-editable  — Creates editable Juspay config at ~/.config/opencode/" \
-      "opencode                  — Plain OpenCode, no config")
+    choice=$(gum choose --header "Choose a coding agent:" \
+      "claude-code-juspay-oneclick — Claude Code with Juspay config and skills" \
+      "opencode-juspay-oneclick    — OpenCode with Juspay config and skills" \
+      "opencode-oneclick           — OpenCode with skills, bring your own provider" \
+      "opencode-juspay-editable    — OpenCode with editable Juspay config at ~/.config/opencode/" \
+      "opencode                    — Plain OpenCode, no config")
 
     case "$choice" in
-      opencode-juspay-oneclick*)  exec ${lib.getExe opencode-juspay-oneclick} "$@" ;;
-      opencode-oneclick*)         exec ${lib.getExe opencode-oneclick} "$@" ;;
-      opencode-juspay-editable*)  exec ${lib.getExe opencode-juspay-editable} "$@" ;;
-      opencode*)                  exec ${lib.getExe opencode} "$@" ;;
-      *)                          echo "No selection made."; exit 1 ;;
+      claude-code-juspay-oneclick*) exec ${lib.getExe claude-code-juspay-oneclick} "$@" ;;
+      opencode-juspay-oneclick*)    exec ${lib.getExe opencode-juspay-oneclick} "$@" ;;
+      opencode-oneclick*)           exec ${lib.getExe opencode-oneclick} "$@" ;;
+      opencode-juspay-editable*)    exec ${lib.getExe opencode-juspay-editable} "$@" ;;
+      opencode*)                    exec ${lib.getExe opencode} "$@" ;;
+      *)                            echo "No selection made."; exit 1 ;;
     esac
   '';
 }

--- a/coding-agents/opencode/packages/lib.nix
+++ b/coding-agents/opencode/packages/lib.nix
@@ -1,33 +1,11 @@
 let
-  # Checks for JUSPAY_API_KEY, skipping for --version/--help.
-  # Uses ${..:-} for nounset (set -u) compatibility.
-  checkApiKey = ''
-    case " $* " in
-      *" --version "* | *" --help "* | *" -v "* | *" -h "*) ;;
-      *)
-        if [ -z "''${JUSPAY_API_KEY:-}" ]; then
-          cat >&2 <<'ERR'
-
-      Error: JUSPAY_API_KEY environment variable is not set.
-
-      Create an API key at: https://grid.ai.juspay.net/dashboard
-      (Requires Juspay VPN to access the dashboard)
-
-      Then run:
-        export JUSPAY_API_KEY=your-api-key
-
-    ERR
-          exit 1
-        fi
-        ;;
-    esac
-  '';
+  sharedLib = import ../../lib.nix;
 in
 {
-  inherit checkApiKey;
+  inherit (sharedLib) checkApiKey;
 
   mkInitScript = configFile: ''
-    ${checkApiKey}
+    ${sharedLib.checkApiKey}
     config_dir="$HOME/.config/opencode"
     config_file="$config_dir/opencode.json"
     if [ ! -f "$config_file" ]; then

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,10 @@
       perSystem = { self', lib, pkgs, system, ... }:
         let
           opencode = pkgs.llm-agents.opencode;
+          claude-code = pkgs.llm-agents.claude-code;
           # callPackageWith auto-injects opencode into package functions that accept it
           callOc = path: lib.callPackageWith (pkgs // { inherit opencode; }) (./coding-agents/opencode/packages + "/${path}");
+          callCc = path: lib.callPackageWith (pkgs // { inherit claude-code; }) (./coding-agents/claude-code + "/${path}");
           juspayConfigFile = callOc "config.nix" { };
           baseConfigFile = callOc "config.nix" { settings = import ./coding-agents/opencode/settings; };
           skillsSrc = skills;
@@ -36,7 +38,7 @@
 
           packages = {
             default = callOc "default.nix" {
-              inherit (self'.packages) opencode-juspay-editable opencode-juspay-oneclick opencode-oneclick;
+              inherit (self'.packages) opencode-juspay-editable opencode-juspay-oneclick opencode-oneclick claude-code-juspay-oneclick;
             };
             inherit opencode;
             opencode-juspay-editable = callOc "juspay-editable.nix" {
@@ -48,6 +50,9 @@
             };
             opencode-oneclick = callOc "oneclick.nix" {
               configFile = baseConfigFile;
+              inherit skillsSrc;
+            };
+            claude-code-juspay-oneclick = callCc "juspay-oneclick.nix" {
               inherit skillsSrc;
             };
           };


### PR DESCRIPTION
**Claude Code joins the selector menu** alongside OpenCode, wired up with Juspay's LLM grid and bundled skills via `--add-dir`.

The wrapper sets all the env vars from the official `jclaude()` pattern — base URL, model overrides, timeouts, feature flags — and injects skills from `juspay/skills` using Claude Code's `--add-dir` directory discovery. `checkApiKey` is extracted into a shared lib so both agents DRY on validation.

*No home-manager module or editable variant yet — just the oneclick Juspay wrapper to start.*

Closes #22

### Try it locally
```
nix run github:juspay/AI/add-claude-code#claude-code-juspay-oneclick
```