### PR TITLE
Prompt for JUSPAY_API_KEY when unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This launches an interactive selector. Or run a specific variant directly:
 | `opencode-juspay-editable` | `nix run github:juspay/AI#opencode-juspay-editable` | Creates editable Juspay config at `~/.config/opencode/opencode.json` ([customize](https://opencode.ai/docs/config/)) |
 | `opencode` | `nix run github:juspay/AI#opencode` | Plain OpenCode, no config |
 
-The `JUSPAY_API_KEY` environment variable must be set when running the `opencode-juspay-*` variants.
+The `opencode-juspay-*` variants need a `JUSPAY_API_KEY`. If the env var isn't set, the wrapper prompts for it interactively — handy on fresh VMs or containers. Export the var in your shell to skip the prompt on subsequent runs.
 
 ### Daily Updates
 

--- a/coding-agents/opencode/packages/juspay-editable.nix
+++ b/coding-agents/opencode/packages/juspay-editable.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, opencode, configFile }:
 let
-  ocLib = import ./lib.nix;
+  ocLib = import ./lib.nix { inherit pkgs; };
 in
 pkgs.writeShellApplication {
   name = "opencode";

--- a/coding-agents/opencode/packages/juspay-oneclick.nix
+++ b/coding-agents/opencode/packages/juspay-oneclick.nix
@@ -1,12 +1,12 @@
 { pkgs, lib, opencode, configFile, skillsDir }:
 let
-  ocLib = import ./lib.nix;
+  ocLib = import ./lib.nix { inherit pkgs; };
   configDir = ocLib.mkConfigDir { inherit pkgs configFile skillsDir; };
 in
 pkgs.writeShellApplication {
   name = "opencode";
   text = ''
-    ${ocLib.checkApiKey}
+    ${ocLib.ensureApiKey}
     export OPENCODE_CONFIG_DIR=${configDir}
     exec ${lib.getExe opencode} "$@"
   '';

--- a/coding-agents/opencode/packages/lib.nix
+++ b/coding-agents/opencode/packages/lib.nix
@@ -1,33 +1,47 @@
+{ pkgs }:
 let
-  # Checks for JUSPAY_API_KEY, skipping for --version/--help.
+  gumBin = "${pkgs.gum}/bin/gum";
+  # Ensures JUSPAY_API_KEY is set, prompting interactively if missing.
+  # Skipped for --version/--help so those stay non-interactive.
   # Uses ${..:-} for nounset (set -u) compatibility.
-  checkApiKey = ''
+  ensureApiKey = ''
     case " $* " in
       *" --version "* | *" --help "* | *" -v "* | *" -h "*) ;;
       *)
         if [ -z "''${JUSPAY_API_KEY:-}" ]; then
-          cat >&2 <<'ERR'
+          cat >&2 <<'MSG'
 
-      Error: JUSPAY_API_KEY environment variable is not set.
+      JUSPAY_API_KEY is not set.
 
       Create an API key at: https://grid.ai.juspay.net/dashboard
       (Requires Juspay VPN to access the dashboard)
 
-      Then run:
-        export JUSPAY_API_KEY=your-api-key
+      Tip: export JUSPAY_API_KEY=... to skip this prompt next time.
 
-    ERR
-          exit 1
+    MSG
+          if [ ! -t 0 ]; then
+            echo "Error: cannot prompt for JUSPAY_API_KEY (stdin is not a terminal)." >&2
+            exit 1
+          fi
+          JUSPAY_API_KEY=$(${gumBin} input --password --prompt "JUSPAY_API_KEY: ") || {
+            echo "Error: failed to read JUSPAY_API_KEY." >&2
+            exit 1
+          }
+          if [ -z "$JUSPAY_API_KEY" ]; then
+            echo "Error: no API key provided." >&2
+            exit 1
+          fi
+          export JUSPAY_API_KEY
         fi
         ;;
     esac
   '';
 in
 {
-  inherit checkApiKey;
+  inherit ensureApiKey;
 
   mkInitScript = configFile: ''
-    ${checkApiKey}
+    ${ensureApiKey}
     config_dir="$HOME/.config/opencode"
     config_file="$config_dir/opencode.json"
     if [ ! -f "$config_file" ]; then

--- a/coding-agents/opencode/packages/oneclick.nix
+++ b/coding-agents/opencode/packages/oneclick.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, opencode, configFile, skillsDir }:
 let
-  ocLib = import ./lib.nix;
+  ocLib = import ./lib.nix { inherit pkgs; };
   configDir = ocLib.mkConfigDir { inherit pkgs configFile skillsDir; };
 in
 pkgs.writeShellApplication {


### PR DESCRIPTION
## Summary

Lets the juspay variants of the `opencode` wrapper run on a **fresh VM or container** with no prior user config. When `JUSPAY_API_KEY` is missing, the wrapper now **prompts for it interactively** (via `gum input --password`) instead of exiting with an error. The one-time message still tells users to `export JUSPAY_API_KEY=...` so they can skip the prompt on subsequent runs.

Non-TTY invocations still fail fast with a clear error, and `--version` / `--help` continue to bypass the check — so scripts and the existing NixOS tests keep working unchanged.

Touches `coding-agents/opencode/packages/lib.nix` and its three consumers.

## Test plan

- [x] `nix build .#opencode-juspay-oneclick .#opencode-juspay-editable .#opencode-oneclick`
- [x] Wrapper with `JUSPAY_API_KEY` unset and `--version` prints version (bypass works)
- [x] Wrapper with `JUSPAY_API_KEY` unset and stdin piped errors out cleanly (non-TTY guard)
- [ ] Try interactively on a fresh machine with no env var set (verify `gum input --password` flow)