### PR TITLE
Skip variant chooser when args are passed

### DIFF
--- a/coding-agents/opencode/packages/default.nix
+++ b/coding-agents/opencode/packages/default.nix
@@ -3,6 +3,10 @@ pkgs.writeShellApplication {
   name = "opencode";
   runtimeInputs = [ pkgs.gum ];
   text = ''
+    if [ "$#" -gt 0 ]; then
+      exec ${lib.getExe opencode-juspay-oneclick} "$@"
+    fi
+
     choice=$(gum choose --header "Choose OpenCode variant:" \
       "opencode-juspay-oneclick  — Juspay config and skills bundled" \
       "opencode-oneclick         — Skills bundled, bring your own provider" \
@@ -10,10 +14,10 @@ pkgs.writeShellApplication {
       "opencode                  — Plain OpenCode, no config")
 
     case "$choice" in
-      opencode-juspay-oneclick*)  exec ${lib.getExe opencode-juspay-oneclick} "$@" ;;
-      opencode-oneclick*)         exec ${lib.getExe opencode-oneclick} "$@" ;;
-      opencode-juspay-editable*)  exec ${lib.getExe opencode-juspay-editable} "$@" ;;
-      opencode*)                  exec ${lib.getExe opencode} "$@" ;;
+      opencode-juspay-oneclick*)  exec ${lib.getExe opencode-juspay-oneclick} ;;
+      opencode-oneclick*)         exec ${lib.getExe opencode-oneclick} ;;
+      opencode-juspay-editable*)  exec ${lib.getExe opencode-juspay-editable} ;;
+      opencode*)                  exec ${lib.getExe opencode} ;;
       *)                          echo "No selection made."; exit 1 ;;
     esac
   '';


### PR DESCRIPTION
## Summary

Fixes #71. When `nix run github:juspay/AI -- <args>` is invoked with arguments, skip the interactive `gum choose` prompt and forward directly to `opencode-juspay-oneclick`. The chooser only made sense for bare launches; with args (e.g. `-- run "hello"`), the user is being intentional and shouldn't have to click through a menu first.

Bare `nix run github:juspay/AI` still shows the chooser as before.

## Test plan

- [ ] `nix run .` (no args) → chooser appears as before
- [ ] `nix run . -- --version` → prints version, no chooser
- [ ] `nix run . -- run "hello"` → forwards directly to `opencode-juspay-oneclick run "hello"`, no chooser