### PR TITLE
Fix oneclick wrappers under updated opencode (writable OPENCODE_CONFIG_DIR)

### DIFF
--- a/coding-agents/opencode/packages/juspay-oneclick.nix
+++ b/coding-agents/opencode/packages/juspay-oneclick.nix
@@ -1,13 +1,12 @@
 { pkgs, lib, opencode, configFile, skillsDir }:
 let
   ocLib = import ./lib.nix { inherit pkgs; };
-  configDir = ocLib.mkConfigDir { inherit pkgs configFile skillsDir; };
 in
 pkgs.writeShellApplication {
   name = "opencode";
   text = ''
     ${ocLib.ensureApiKey}
-    export OPENCODE_CONFIG_DIR=${configDir}
+    ${ocLib.setupConfigDir { inherit configFile skillsDir; }}
     exec ${lib.getExe opencode} "$@"
   '';
 }

--- a/coding-agents/opencode/packages/lib.nix
+++ b/coding-agents/opencode/packages/lib.nix
@@ -1,6 +1,8 @@
 { pkgs }:
 let
   gumBin = "${pkgs.gum}/bin/gum";
+  mktempBin = "${pkgs.coreutils}/bin/mktemp";
+  lnBin = "${pkgs.coreutils}/bin/ln";
   # Ensures JUSPAY_API_KEY is set, prompting interactively if missing.
   # Always runs — we don't bypass based on args, so the user's positional
   # parameters reach opencode untouched (the prior `case " $* "` bypass
@@ -48,10 +50,13 @@ in
     fi
   '';
 
-  mkConfigDir = { pkgs, configFile, skillsDir }:
-    pkgs.runCommand "opencode-config-dir" { } ''
-      mkdir -p $out
-      ln -s ${configFile} $out/opencode.json
-      ln -s ${skillsDir} $out/skills
-    '';
+  # Sets up OPENCODE_CONFIG_DIR as a writable per-run temp directory containing
+  # opencode.json and skills/. Opencode writes a .gitignore into this dir, so
+  # it cannot be a /nix/store path (would EROFS).
+  setupConfigDir = { configFile, skillsDir }: ''
+    OPENCODE_CONFIG_DIR=$(${mktempBin} -d -t opencode-config-XXXXXX)
+    ${lnBin} -s ${configFile} "$OPENCODE_CONFIG_DIR/opencode.json"
+    ${lnBin} -s ${skillsDir} "$OPENCODE_CONFIG_DIR/skills"
+    export OPENCODE_CONFIG_DIR
+  '';
 }

--- a/coding-agents/opencode/packages/oneclick.nix
+++ b/coding-agents/opencode/packages/oneclick.nix
@@ -1,12 +1,11 @@
 { pkgs, lib, opencode, configFile, skillsDir }:
 let
   ocLib = import ./lib.nix { inherit pkgs; };
-  configDir = ocLib.mkConfigDir { inherit pkgs configFile skillsDir; };
 in
 pkgs.writeShellApplication {
   name = "opencode";
   text = ''
-    export OPENCODE_CONFIG_DIR=${configDir}
+    ${ocLib.setupConfigDir { inherit configFile skillsDir; }}
     exec ${lib.getExe opencode} "$@"
   '';
 }

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771437256,
-        "narHash": "sha256-bLqwib+rtyBRRVBWhMuBXPCL/OThfokA+j6+uH7jDGU=",
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "06ee7190dc2620ea98af9eb225aa9627b68b0e33",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
         "type": "github"
       },
       "original": {
@@ -31,7 +31,6 @@
           "llm-agents",
           "flake-parts"
         ],
-        "import-tree": "import-tree",
         "nixpkgs": [
           "llm-agents",
           "nixpkgs"
@@ -46,16 +45,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776182890,
-        "narHash": "sha256-+/VOe8XGq5klpU+I19D+3TcaR7o+Cwbq67KNF7mcFak=",
-        "owner": "Mic92",
+        "lastModified": 1777369708,
+        "narHash": "sha256-1xW7cRZNsFNPQD+cE0fwnLVStnDth0HSoASEIFeT7uI=",
+        "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "648d293c51e981aec9cb07ba4268bc19e7a8c575",
+        "rev": "e659e1cc4b8e1b21d0aa85f1c481f9db61ecfa98",
         "type": "github"
       },
       "original": {
-        "owner": "Mic92",
-        "ref": "catalog-support",
+        "owner": "nix-community",
+        "ref": "staging-2.1.0",
         "repo": "bun2nix",
         "type": "github"
       }
@@ -81,21 +80,6 @@
         "type": "github"
       }
     },
-    "import-tree": {
-      "locked": {
-        "lastModified": 1763762820,
-        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
-        "owner": "vic",
-        "repo": "import-tree",
-        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vic",
-        "repo": "import-tree",
-        "type": "github"
-      }
-    },
     "llm-agents": {
       "inputs": {
         "blueprint": "blueprint",
@@ -106,11 +90,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1776190070,
-        "narHash": "sha256-0oS3UnrgShH5WVNgFlLSFBEurUL/HN8zLiw8PW9dT14=",
+        "lastModified": 1777672144,
+        "narHash": "sha256-dXUaa92UxZwcJKZETKOa/J6A95PnQFUBIkyL3y5FUDU=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "f7212243ee04a467686c253e9cbced84bf942488",
+        "rev": "b5a2e39e6494c9139a600c6ffccb042099d864cd",
         "type": "github"
       },
       "original": {
@@ -121,11 +105,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1777548390,
+        "narHash": "sha256-WacE23EbHTsBKvr8cu+1DFNbP6Rh1brHUH5SDUI0NQI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "7aaa00e7cc9be6c316cb5f6617bd740dd435c59d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

PR #68 (flake input update) bumps `llm-agents` and brings opencode from
1.4.3 to 1.14.31. The new opencode writes a `.gitignore` into
`OPENCODE_CONFIG_DIR` on startup, so the read-only `/nix/store` path
that the `oneclick` and `juspay-oneclick` wrappers point that env var
at fails with:

```
PlatformError Unknown: FileSystem.writeFile (/nix/store/.../.gitignore)
cause=Error: EROFS: read-only file system, open '/nix/store/.../.gitignore'
    at LA (/$bunfs/root/chunk-2jj9v4nh.js:71:4213)
    at <anonymous> (/$bunfs/root/chunk-10eecb7y.js:709:10709)
```

This PR includes the same flake input bump as #68 and adds the wrapper
fix on top.

- Replace the `mkConfigDir` derivation with a runtime `setupConfigDir`
  shell snippet that creates a per-run `mktemp` directory and symlinks
  `opencode.json` and `skills/` into it. The dir is now writable, so
  opencode can drop its `.gitignore` there.
- Apply to both `oneclick.nix` and `juspay-oneclick.nix`.
- The plain `opencode` package (no wrapper) was unaffected and is
  unchanged.

Closes #68 (supersedes — same lock update plus the runtime fix).

## Test plan

- [x] `nix build .#opencode-juspay-oneclick` and
  `.#opencode-oneclick` build successfully on the updated inputs.
- [x] Running the built wrapper boots opencode past config setup
  without `EROFS` (only fails later on the auth check, as expected with
  a fake key).
- [ ] CI green.
- [ ] `nix run github:juspay/AI/fix-oneclick-config-dir-rofs` end-to-end
  with a real `JUSPAY_API_KEY`.