### PR TITLE
opencode: expose a Home Manager module for config-only installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ The `opencode-juspay-*` variants need a `JUSPAY_API_KEY`. If the env var isn't s
 
 This flake's `flake.lock` is **auto-updated daily** via CI, so you always get the latest OpenCode release and skills. If pinning via `flake.lock` in your own flake, run `nix flake update AI` to pull the latest.
 
+## Home Manager module (config only)
+
+If you manage your environment with [Home Manager](https://nix-community.github.io/home-manager/) and already have an `opencode` binary — from `nixpkgs`, or bundled with another tool — you can install **just the Juspay config**, without a wrapper or a second opencode, via the exposed module:
+
+```nix
+# flake inputs
+juspay-ai.url = "github:juspay/AI";
+
+# home configuration
+{
+  imports = [ inputs.juspay-ai.homeModules.opencode ];
+  programs.opencode-juspay.enable = true;
+}
+```
+
+This renders the same `opencode.json` as the packaged variants and writes it to `$XDG_CONFIG_HOME/opencode/opencode.json`. As with the `opencode-juspay-*` variants, the Juspay provider needs `JUSPAY_API_KEY` in the environment at runtime.
+
+| Option | Default | Description |
+|---|---|---|
+| `programs.opencode-juspay.enable` | `false` | Install the config (no binary). |
+| `programs.opencode-juspay.juspay` | `true` | Include the Juspay litellm provider/model settings. Set `false` for the base settings only. |
+| `programs.opencode-juspay.settings` | `{}` | Extra opencode settings merged on top. |
+
+The module is system-agnostic — it uses your config's `pkgs`, so it does not pull in this flake's `nixpkgs`.
+
 ## Tips
 
 ### Web UI
@@ -97,7 +122,7 @@ AI_AGENT='claude --dangerously-skip-permissions' just agent
 ├── .opencode/                # Vendored APM output for OpenCode
 ├── agent/                    # Justfile recipes for apm and agent launch
 ├── coding-agents/
-│   └── opencode/             # OpenCode packages, settings, tests
+│   └── opencode/             # OpenCode packages, settings, home-module, tests
 ├── demo/                     # Demo screencast infrastructure
 ```
 

--- a/coding-agents/opencode/home-module.nix
+++ b/coding-agents/opencode/home-module.nix
@@ -1,0 +1,66 @@
+# Home Manager module: install the opencode *configuration* (not the binary).
+#
+# Renders the same opencode.json as
+# `coding-agents/opencode/packages/config.nix` and places it at
+# `$XDG_CONFIG_HOME/opencode/opencode.json`. The opencode package itself is
+# intentionally NOT installed — bring your own binary. Use this when you want
+# Juspay's opencode config (the litellm gateway + model catalog) layered onto
+# an opencode you manage elsewhere.
+#
+# Usage (flake-based home-manager):
+#
+#   # flake inputs:
+#   juspay-ai.url = "github:juspay/AI";
+#
+#   # home configuration:
+#   imports = [ inputs.juspay-ai.homeModules.opencode ];
+#   programs.opencode-juspay.enable = true;
+#
+# The Juspay provider expects JUSPAY_API_KEY in the environment at runtime
+# (create one at https://grid.ai.juspay.net/dashboard, requires Juspay VPN).
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.opencode-juspay;
+  inherit (lib) mkEnableOption mkOption mkIf types optionalAttrs;
+
+  baseSettings = import ./settings;
+  juspaySettings = import ./settings/juspay.nix;
+
+  settings =
+    baseSettings
+    // optionalAttrs cfg.juspay juspaySettings
+    // cfg.settings;
+
+  # Reuse the canonical renderer so the module and the packaged variants
+  # cannot drift apart.
+  configFile = import ./packages/config.nix { inherit pkgs settings; };
+in
+{
+  options.programs.opencode-juspay = {
+    enable = mkEnableOption "the Juspay opencode configuration (config only, no package)";
+
+    juspay = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Include the Juspay provider/model settings — the litellm gateway at
+        grid.ai.juspay.net, which expects JUSPAY_API_KEY at runtime. Set to
+        false to install only the upstream base settings.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.attrs;
+      default = { };
+      example = lib.literalExpression ''{ theme = "tokyonight"; }'';
+      description = ''
+        Extra opencode settings merged on top of the base (and, when
+        {option}`programs.opencode-juspay.juspay` is enabled, Juspay) settings.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    xdg.configFile."opencode/opencode.json".source = configFile;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -58,5 +58,14 @@
       apps = forAllSystems (system:
         nixpkgs.lib.mapAttrs (_: pkg: { program = nixpkgs.lib.getExe pkg; type = "app"; }) self.packages.${system}
       );
+
+      # Home Manager module that installs the opencode *configuration* only
+      # (not the binary). System-agnostic — it uses the importing config's
+      # pkgs, so it does not depend on this flake's nixpkgs. See the module
+      # header for usage.
+      homeModules = {
+        opencode = ./coding-agents/opencode/home-module.nix;
+        default = self.homeModules.opencode;
+      };
     };
 }


### PR DESCRIPTION
## What

Adds `homeModules.opencode` (and `homeModules.default`) — a system-agnostic Home Manager module that installs the opencode **configuration only**, not the binary.

```nix
# flake inputs
juspay-ai.url = "github:juspay/AI";

# home configuration
imports = [ inputs.juspay-ai.homeModules.opencode ];
programs.opencode-juspay.enable = true;
```

It renders the same `opencode.json` as `coding-agents/opencode/packages/config.nix` and places it at `$XDG_CONFIG_HOME/opencode/opencode.json`.

## Why

The flake currently only exposes **packages** that bundle a config *with* an opencode binary (`opencode-juspay-editable`, `opencode-juspay-oneclick`, …). There was no clean way to consume **just the Juspay config** layered onto an opencode binary managed elsewhere (e.g. one that ships with another tool).

Without this, a downstream config has to set `flake = false`, reach into `coding-agents/opencode/settings`, and re-implement the merge + JSON generation by hand — duplicating `config.nix` and coupling to internal paths. This module removes that need.

## Design

- **Config only, no package** — sets `xdg.configFile."opencode/opencode.json"`, installs nothing.
- **System-agnostic** — uses the importing config's `pkgs`, so it does not depend on this flake's `nixpkgs`/`llm-agents`.
- **No drift** — reuses `packages/config.nix` as the canonical renderer rather than re-implementing it.

## Options

- `programs.opencode-juspay.enable` — turn it on.
- `programs.opencode-juspay.juspay` (default `true`) — include the Juspay litellm provider/model settings (gateway at `grid.ai.juspay.net`, expects `JUSPAY_API_KEY` at runtime). Set `false` for upstream base settings only.
- `programs.opencode-juspay.settings` (attrs) — extra settings merged on top.

## Test

Verified by consuming it from a downstream nix-darwin + NixOS config (`homeConfigurations."srid@zest"` and `nixosConfigurations.pureintent`): both build, and the rendered `opencode.json` matches the `opencode-juspay-editable` config byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)