### PR TITLE
flake: add `oneclick` alias for opencode-juspay-oneclick

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,8 @@
             configFile = baseConfigFile;
             inherit skillsDir;
           };
+          # Convenience alias: `nix run .#oneclick`
+          oneclick = self.packages.${system}.opencode-juspay-oneclick;
         }
       );
 


### PR DESCRIPTION
## What

Adds a convenience package alias `oneclick` that points to `opencode-juspay-oneclick`, so users can run:

```sh
nix run .#oneclick
```

instead of the longer `nix run .#opencode-juspay-oneclick`.

## How

`apps` is derived from `packages` via `mapAttrs`, so adding the `oneclick` attribute to the `packages` set automatically exposes it as both a package and a runnable app. The alias references the existing package directly — no rebuild, identical store path.

Verified both resolve to the same `opencode` derivation:

```
nix eval .#apps.x86_64-linux.oneclick.program
nix eval .#apps.x86_64-linux.opencode-juspay-oneclick.program
# → both "/nix/store/.../opencode/bin/opencode"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)