### PR TITLE
feat(opencode): add kimi-k3 Juspay model

### DIFF
--- a/coding-agents/opencode/settings/juspay.nix
+++ b/coding-agents/opencode/settings/juspay.nix
@@ -49,6 +49,7 @@ let
     glm-high                = glmLimits // { reasoningEffort = "high"; id = "glm-latest"; };
     glm-fast                = glmLimits // { reasoningEffort = "none"; id = "glm-latest"; };
     kimi-latest             = { context = 262000;  output = 32000; };
+    kimi-k3                 = { context = 256000;  output = 32000; };
   };
 in
 {


### PR DESCRIPTION
## Summary
- Add `kimi-k3` to Juspay OpenCode models (`context = 256000`, `output = 32000`)
- Available as `litellm/kimi-k3` on the Juspay provider

<img width="1498" height="728" alt="image" src="https://github.com/user-attachments/assets/0aec881d-d135-4516-90ea-7b42fe29fd6c" />
