### PR TITLE
feat(pi): add pi coding agent with Juspay LiteLLM support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
       - name: nix build
         run: nix build --print-build-logs
 
+      - name: nix build pi variants
+        run: |
+          nix build --print-build-logs .#pi .#pi-juspay-oneclick .#pi-juspay-editable
+
       - name: nix run .#opencode (non-interactive prompt)
         # opencode runs a prompt without any provider API key (bundled model).
         # Fails the job if the run errors (set -e) or produces no output.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 One-click coding agents with Juspay's LLM configuration.
 
-Currently supports **[OpenCode](https://opencode.ai/)** only. Skills are sourced from:
+Supports **[OpenCode](https://opencode.ai/)** and **[pi](https://github.com/badlogic/pi-mono)**. Skills are sourced from:
 
 - [juspay/skills](https://github.com/juspay/skills) — Shared AI agent skills
 - [anthropics/skills](https://github.com/anthropics/skills) — `frontend-design` skill
@@ -25,6 +25,8 @@ nix run github:juspay/AI
 
 This launches an interactive selector. Or run a specific variant directly:
 
+**OpenCode**
+
 | Variant | Command | Description |
 |---|---|---|
 | `opencode-juspay-oneclick` | `nix run github:juspay/AI#opencode-juspay-oneclick` | Juspay config and skills bundled |
@@ -32,7 +34,15 @@ This launches an interactive selector. Or run a specific variant directly:
 | `opencode-juspay-editable` | `nix run github:juspay/AI#opencode-juspay-editable` | Creates editable Juspay config at `~/.config/opencode/opencode.json` ([customize](https://opencode.ai/docs/config/)) |
 | `opencode` | `nix run github:juspay/AI#opencode` | Plain OpenCode, no config |
 
-The `opencode-juspay-*` variants need a `JUSPAY_API_KEY`. If the env var isn't set, the wrapper prompts for it interactively — handy on fresh VMs or containers. Export the var in your shell to skip the prompt on subsequent runs.
+**pi**
+
+| Variant | Command | Description |
+|---|---|---|
+| `pi-juspay-oneclick` | `nix run github:juspay/AI#pi-juspay-oneclick` | Juspay config and skills bundled |
+| `pi-juspay-editable` | `nix run github:juspay/AI#pi-juspay-editable` | Merges Juspay models into `~/.pi/models.json` ([customize](https://github.com/badlogic/pi-mono)) |
+| `pi` | `nix run github:juspay/AI#pi` | Plain pi, no config |
+
+The `*-juspay-*` variants need a `JUSPAY_API_KEY`. If the env var isn't set, the wrapper prompts for it interactively — handy on fresh VMs or containers. Export the var in your shell to skip the prompt on subsequent runs.
 
 ### Daily Updates
 
@@ -98,6 +108,27 @@ GLM-5.2 collapses low/medium into "high", so these are the only distinct levels:
 The tiers are defined in [`coding-agents/opencode/settings/juspay.nix`](coding-agents/opencode/settings/juspay.nix);
 all target the same gateway model (`glm-latest`) and differ only in `reasoningEffort`.
 
+### pi and the LiteLLM gateway
+
+pi (badlogic/pi-mono) supports arbitrary OpenAI-compatible endpoints via its
+`~/.pi/agent/models.json`. The `pi-juspay-*` variants generate this file from
+the same shared catalog as the OpenCode config, keeping model ids and limits
+in sync between the two agents.
+
+To use a model with pi:
+
+```bash
+# Interactive (prompts for JUSPAY_API_KEY if not set)
+nix run github:juspay/AI#pi-juspay-oneclick -- --model litellm/kimi-k3
+
+# With API key already exported: oneclick keeps pi's state off ~/.pi; the
+# editable variant instead merges Juspay into your existing ~/.pi/models.json
+nix run github:juspay/AI#pi-juspay-editable -- --model litellm/glm-latest
+```
+
+You can also select a reasoning-effort tier per session with pi's thinking
+suffix, e.g. `--model litellm/glm-latest:max` or `--model litellm/glm-latest,low,med,high`.
+
 ## Coding Agent Setup
 
 This repo uses [APM](https://microsoft.github.io/apm/) for coding agent configuration. `.claude/` and `.opencode/` are **vendored** — committed to git and kept in sync by a CI check (`apm-sync` workflow).
@@ -122,7 +153,9 @@ AI_AGENT='claude --dangerously-skip-permissions' just agent
 ├── .opencode/                # Vendored APM output for OpenCode
 ├── agent/                    # Justfile recipes for apm and agent launch
 ├── coding-agents/
-│   └── opencode/             # OpenCode packages, settings, home-module, tests
+│   ├── catalog.nix           # Shared Juspay model catalog (opencode, pi)
+│   ├── opencode/             # OpenCode packages, settings, home-module, tests
+│   └── pi/                   # pi packages and models.json generation
 ├── demo/                     # Demo screencast infrastructure
 ```
 

--- a/coding-agents/catalog.nix
+++ b/coding-agents/catalog.nix
@@ -1,0 +1,44 @@
+# Single source of truth for the Juspay LiteLLM gateway
+# (https://grid.ai.juspay.net) model catalog, shared by every coding agent
+# this repo packages (opencode, pi). Adding or tuning a model here updates
+# all agents at once, keeping their model ids and limits in sync.
+#
+# Each entry:
+#   context   - context window in tokens
+#   output    - max output tokens
+#   reasoning - whether the model reasons by default (optional)
+let
+  # GLM-5.2 shares a 1M-token context window (the old 202752 was a copy-paste
+  # default). output stays at 32000: custom-provider clients cap the wire
+  # max_tokens at 32000 for this model regardless of this field (verified
+  # with opencode), so a higher value would only shrink the usable input
+  # budget without raising the real output limit.
+  glmLimits = { context = 1000000; output = 32000; };
+in
+{
+  gatewayUrl = "https://grid.ai.juspay.net";
+  apiKeyEnv = "JUSPAY_API_KEY";
+
+  # All models accept text+image input and produce text output.
+  #
+  # glm-latest is GLM-5.2 and reasons by default. Each agent exposes the
+  # effort tiers its own way: opencode gets sibling picker entries (glm-max /
+  # glm-high / glm-fast — injected in opencode/settings/juspay.nix), pi takes
+  # a per-session thinking level via `--model litellm/glm-latest:max` etc.
+  models = {
+    open-large              = { context = 202752;  output = 32000; };
+    open-fast               = { context = 196000;  output = 32000; };
+    open-vision             = { context = 262144;  output = 32000; };
+    claude-opus-4-5         = { context = 1000000; output = 128000; };
+    claude-opus-4-6         = { context = 1000000; output = 128000; };
+    claude-sonnet-4-6       = { context = 200000;  output = 64000; };
+    claude-sonnet-4-5       = { context = 200000;  output = 32000; };
+    glm-flash-experimental  = { context = 262144;  output = 32000; };
+    gemini-3-pro-preview    = { context = 1048576; output = 65535; };
+    gemini-3-flash-preview  = { context = 1048576; output = 65535; };
+    minimax-m2              = { context = 202752;  output = 32000; };
+    glm-latest              = glmLimits // { reasoning = true; };
+    kimi-latest             = { context = 262000;  output = 32000; };
+    kimi-k3                 = { context = 256000;  output = 32000; };
+  };
+}

--- a/coding-agents/opencode/settings/juspay.nix
+++ b/coding-agents/opencode/settings/juspay.nix
@@ -1,12 +1,12 @@
 let
-  # All models accept text+image input, text output; name = attr key.
-  # reasoningEffort (optional) marks the model as a reasoning model and is
-  # forwarded as the OpenAI-compatible `reasoning_effort` request field —
+  catalog = import ../../catalog.nix;
+
+  # Adapt the shared catalog (see coding-agents/catalog.nix) to opencode's
+  # provider model schema. name = attr key; reasoningEffort is forwarded as
+  # the OpenAI-compatible `reasoning_effort` request field —
   # @ai-sdk/openai-compatible maps the camelCase key to snake_case for us.
-  # id (optional) sets the wire model id when the attr key differs from the
-  # gateway's model name — used to expose one gateway model at several
-  # reasoning-effort tiers.
-  mkModel = name: { context, output, reasoningEffort ? null, id ? null }:
+  mkModel = name:
+    { context, output, reasoning ? false, reasoningEffort ? null, id ? null }:
     let
       base = {
         inherit name;
@@ -14,43 +14,21 @@ let
         limit = { inherit context output; };
       } // (if id == null then { } else { inherit id; });
     in
-    if reasoningEffort == null then base
-    else base // {
-      reasoning = true;
-      options = { inherit reasoningEffort; };
-    };
+    base
+    // (if reasoning then { inherit reasoning; } else { })
+    // (if reasoningEffort == null then { } else { options = { inherit reasoningEffort; }; });
 
-  # GLM-5.2 (glm-latest and its effort-tier siblings) share a 1M-token context
-  # window (the old 202752 was a copy-paste default). output stays at 32000:
-  # OpenCode caps the wire max_tokens at 32000 for this custom-provider model
-  # regardless of this field (verified), so a higher value would only shrink the
-  # usable input budget without raising the real output limit.
-  glmLimits = { context = 1000000; output = 32000; };
-
-  models = builtins.mapAttrs mkModel {
-    open-large              = { context = 202752;  output = 32000; };
-    open-fast               = { context = 196000;  output = 32000; };
-    open-vision             = { context = 262144;  output = 32000; };
-    claude-opus-4-5         = { context = 1000000; output = 128000; };
-    claude-opus-4-6         = { context = 1000000; output = 128000; };
-    claude-sonnet-4-6       = { context = 200000;  output = 64000; };
-    claude-sonnet-4-5       = { context = 200000;  output = 32000; };
-    glm-flash-experimental  = { context = 262144;  output = 32000; };
-    gemini-3-pro-preview    = { context = 1048576; output = 65535; };
-    gemini-3-flash-preview  = { context = 1048576; output = 65535; };
-    minimax-m2              = { context = 202752;  output = 32000; };
-    # glm-latest is GLM-5.2. Its default reasoning is left untouched (no
-    # reasoning_effort sent — the gateway default, which is thinking-on). The
-    # effort tiers below are sibling picker entries that target the same gateway
-    # model via `id`; GLM-5.2 collapses low/medium into "high", so max / high /
-    # off are the only distinct levels.
-    glm-latest              = glmLimits;
-    glm-max                 = glmLimits // { reasoningEffort = "max";  id = "glm-latest"; };
-    glm-high                = glmLimits // { reasoningEffort = "high"; id = "glm-latest"; };
-    glm-fast                = glmLimits // { reasoningEffort = "none"; id = "glm-latest"; };
-    kimi-latest             = { context = 262000;  output = 32000; };
-    kimi-k3                 = { context = 256000;  output = 32000; };
+  # GLM-5.2 collapses low/medium into "high", so the picker exposes the same
+  # gateway model at the three distinct effort tiers below (glm-latest itself
+  # stays at the gateway default, thinking-on, with no reasoning_effort sent).
+  glmLimits = catalog.models.glm-latest;
+  effortTiers = {
+    glm-max  = glmLimits // { reasoning = true; reasoningEffort = "max";  id = "glm-latest"; };
+    glm-high = glmLimits // { reasoning = true; reasoningEffort = "high"; id = "glm-latest"; };
+    glm-fast = glmLimits // { reasoningEffort = "none"; id = "glm-latest"; };
   };
+
+  models = builtins.mapAttrs mkModel (catalog.models // effortTiers);
 in
 {
   model = "litellm/glm-latest";
@@ -60,8 +38,8 @@ in
     npm = "@ai-sdk/openai-compatible";
     name = "Juspay";
     options = {
-      baseURL = "https://grid.ai.juspay.net";
-      apiKey = "{env:JUSPAY_API_KEY}";
+      baseURL = catalog.gatewayUrl;
+      apiKey = "{env:${catalog.apiKeyEnv}}";
       timeout = 600000;
     };
     inherit models;

--- a/coding-agents/pi/juspay-editable.nix
+++ b/coding-agents/pi/juspay-editable.nix
@@ -1,0 +1,15 @@
+{ pkgs, lib, pi, modelsFile }:
+let
+  piLib = import ./lib.nix { inherit pkgs; };
+in
+pkgs.writeShellApplication {
+  name = "pi";
+  text = ''
+    ${piLib.ensureApiKey}
+    # Merge the Juspay providers into the user's existing models.json (pi
+    # merges that file over its built-in catalog), keeping their own
+    # providers, sessions and settings untouched.
+    ${piLib.addProvidersToDir { inherit modelsFile; dir_var = "PI_CODING_AGENT_DIR"; }}
+    exec ${lib.getExe pi} "$@"
+  '';
+}

--- a/coding-agents/pi/juspay-oneclick.nix
+++ b/coding-agents/pi/juspay-oneclick.nix
@@ -1,0 +1,14 @@
+{ pkgs, lib, pi, modelsFile, skillsDir }:
+let
+  piLib = import ./lib.nix { inherit pkgs; };
+in
+pkgs.writeShellApplication {
+  name = "pi";
+  text = ''
+    ${piLib.ensureApiKey}
+    ${piLib.setupAgentDir { inherit modelsFile; }}
+    # --skill is repeatable; our vendored skills are loaded alongside (not
+    # instead of) any skills the user passes themselves.
+    exec ${lib.getExe pi} --skill ${skillsDir} "$@"
+  '';
+}

--- a/coding-agents/pi/lib.nix
+++ b/coding-agents/pi/lib.nix
@@ -1,0 +1,84 @@
+{ pkgs }:
+let
+  gumBin = "${pkgs.gum}/bin/gum";
+  mktempBin = "${pkgs.coreutils}/bin/mktemp";
+  lnBin = "${pkgs.coreutils}/bin/ln";
+  jqBin = "${pkgs.jq}/bin/jq";
+in
+{
+  # Ensures JUSPAY_API_KEY is set, prompting interactively if missing.
+  # Always runs — we don't bypass based on args, so the user's positional
+  # parameters reach pi untouched. Uses ${..:-} for nounset (set -u)
+  # compatibility. Same UX as the opencode wrappers.
+  ensureApiKey = ''
+    if [ -z "''${JUSPAY_API_KEY:-}" ]; then
+      cat >&2 <<'MSG'
+
+  JUSPAY_API_KEY is not set.
+
+  Create an API key at: https://grid.ai.juspay.net/dashboard
+  (Requires Juspay VPN to access the dashboard)
+
+  Tip: export JUSPAY_API_KEY=... to skip this prompt next time.
+
+MSG
+      if [ ! -t 0 ]; then
+        echo "Error: cannot prompt for JUSPAY_API_KEY (stdin is not a terminal)." >&2
+        exit 1
+      fi
+      JUSPAY_API_KEY=$(${gumBin} input --password --prompt "JUSPAY_API_KEY: ") || {
+        echo "Error: failed to read JUSPAY_API_KEY." >&2
+        exit 1
+      }
+      if [ -z "$JUSPAY_API_KEY" ]; then
+        echo "Error: no API key provided." >&2
+        exit 1
+      fi
+      export JUSPAY_API_KEY
+    fi
+  '';
+
+  # Sets up PI_CODING_AGENT_DIR as a writable per-run temp directory
+  # containing a symlink to the given models.json. pi also stores sessions
+  # and settings under PI_CODING_AGENT_DIR, so a temp dir additionally keeps
+  # pi's state off of ~/.pi — handy for throwaway sandboxes.
+  setupAgentDir = { modelsFile }: ''
+    PI_CODING_AGENT_DIR=$(${mktempBin} -d -t pi-agent-XXXXXX)
+    ln -s ${modelsFile} "$PI_CODING_AGENT_DIR/models.json"
+    export PI_CODING_AGENT_DIR
+  '';
+
+  # Writes an editable ${modelsFile} to $config_path if the user has no
+  # models.json there or in legacy ~/.pi/models.json yet (pi reads ~/.pi/
+  # when PI_CODING_AGENT_DIR is unset).
+  mkInitScript = { modelsFile, config_path }: ''
+    if [ ! -f "${config_path}" ] && [ ! -f "$HOME/.pi/models.json" ]; then
+      mkdir -p "$(${pkgs.coreutils}/bin/dirname "${config_path}")"
+      cp ${modelsFile} "${config_path}"
+      chmod u+w "${config_path}"
+    fi
+  '';
+
+  # Registers the providers in ${modelsFile} in pi's *existing* agent dir,
+  # so the same `pi` invocation works against the gateway without
+  # PI_CODING_AGENT_DIR being set (pi merges models.json over its built-in
+  # catalog). Idempotent per provider; anything the user already configured
+  # under the same provider id is overwritten with our version.
+  #
+  # Writes through a temp file + mv for atomicity; if jq is not on PATH we
+  # fall back to the nix-provided jq.
+  addProvidersToDir = { modelsFile, dir_var, jq ? "${jqBin}" }: ''
+    _pi_dir="''${${dir_var}:-$HOME/.pi}"
+    mkdir -p "$_pi_dir"
+    _pi_models="$_pi_dir/models.json"
+    if [ ! -f "$_pi_models" ]; then
+      printf '{ "providers": {} }\n' > "$_pi_models"
+      chmod u+w "$_pi_models"
+    fi
+    _pi_tmp="$(${mktempBin} -t pi-models-XXXXXX)"
+    ${jqBin} -s '.[0].providers = (.[0].providers // {}) + .[1].providers | .[0]' \
+      "$_pi_models" ${modelsFile} > "$_pi_tmp"
+    mv "$_pi_tmp" "$_pi_models"
+    unset _pi_dir _pi_models _pi_tmp
+  '';
+}

--- a/coding-agents/pi/models-json.nix
+++ b/coding-agents/pi/models-json.nix
@@ -1,0 +1,31 @@
+{ pkgs }:
+let
+  catalog = import ../catalog.nix;
+  jsonFormat = pkgs.formats.json { };
+
+  # Adapt the shared catalog (see coding-agents/catalog.nix) to pi's
+  # models.json schema. pi natively supports per-session thinking levels via
+  # `--model litellm/glm-latest:off|low|medium|high|max` on the reasoning
+  # model, so the catalog's plain gateway ids suffice here.
+  #
+  # Verified against grid.ai.juspay.net with pi 0.83.0: both the `developer`
+  # role and the `reasoning_effort` field on reasoning models are accepted,
+  # so no provider-level `compat` overrides are needed.
+  mkModel = name:
+    { context, output, reasoning ? false, ... }:
+    {
+      id = name;
+      inherit name reasoning;
+      input = [ "text" "image" ];
+      contextWindow = context;
+      maxTokens = output;
+    };
+in
+jsonFormat.generate "pi-models.json" {
+  providers.litellm = {
+    baseUrl = catalog.gatewayUrl;
+    api = "openai-completions";
+    apiKey = "\$${catalog.apiKeyEnv}";
+    models = pkgs.lib.mapAttrsToList mkModel catalog.models;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -28,11 +28,16 @@
           pkgs = pkgsFor system;
           lib = pkgs.lib;
           opencode = pkgs.llm-agents.opencode;
+          pi = pkgs.llm-agents.pi;
           callOc = path: lib.callPackageWith (pkgs // { inherit opencode; }) (./coding-agents/opencode/packages + "/${path}");
+          callPi = path: lib.callPackageWith (pkgs // { inherit pi; }) (./coding-agents/pi + "/${path}");
           juspayConfigFile = callOc "config.nix" { };
           baseConfigFile = callOc "config.nix" { settings = import ./coding-agents/opencode/settings; };
           # Vendored by apm — see .opencode/skills/ and apm.yml
           skillsDir = ./.opencode/skills;
+          # models.json rendered from the same shared catalog as the opencode
+          # config, so the two agents agree on model ids and limits.
+          piModelsFile = callPi "models-json.nix" { };
         in
         {
           default = callOc "default.nix" {
@@ -52,6 +57,14 @@
           opencode-oneclick = callOc "oneclick.nix" {
             configFile = baseConfigFile;
             inherit skillsDir;
+          };
+          inherit pi;
+          pi-juspay-oneclick = callPi "juspay-oneclick.nix" {
+            modelsFile = piModelsFile;
+            inherit skillsDir;
+          };
+          pi-juspay-editable = callPi "juspay-editable.nix" {
+            modelsFile = piModelsFile;
           };
           # Convenience alias: `nix run .#oneclick`
           oneclick = self.packages.${system}.opencode-juspay-oneclick;


### PR DESCRIPTION
## Summary

Add first-class support for [pi](https://github.com/badlogic/pi-mono) (`@earendil-works/pi-coding-agent`) against the Juspay LiteLLM gateway (`https://grid.ai.juspay.net`), closing #107.

## Changes

- **Shared catalog** (`coding-agents/catalog.nix`): Extracted the Juspay model catalog into a single source of truth used by both opencode and pi. Adding or tuning a model here now updates both agents at once, keeping model ids and limits in sync.
- **opencode refactor** (`coding-agents/opencode/settings/juspay.nix`): Consumes the shared catalog; opencode config output is semantically identical to before (same models, limits, effort tiers).
- **pi packages** (`coding-agents/pi/`):
  - `pi-juspay-oneclick`: Bundled models.json + vendored skills, state sandboxed to a temp `PI_CODING_AGENT_DIR` (keeps `~/.pi` untouched)
  - `pi-juspay-editable`: Merges Juspay providers into the user's existing `~/.pi/models.json` (or `$PI_CODING_AGENT_DIR`), preserving their own providers/sessions/settings
  - `pi`: Plain pi binary from llm-agents.nix, no config
- **flake.nix**: Wire in `pi`, `pi-juspay-oneclick`, `pi-juspay-editable` packages
- **README**: Document pi variants, usage examples, and the shared-catalog structure
- **CI**: Build pi variants explicitly alongside opencode

## Verified against the gateway

| Test | Result |
|---|---|
| `pi --model litellm/kimi-k3` (plain OpenAI-compat) | OK |
| `pi --model litellm/glm-latest` (reasoning model, default `developer` role) | OK |
| `pi --model litellm/glm-latest:high` (`reasoning_effort` field) | OK |
| `pi-juspay-editable` merges into existing `~/.pi/models.json` without clobbering user providers | OK |
| opencode oneclick still works (regression) | OK |

## Open questions verified

- **`developer` role**: Accepted by the gateway — no `compat.supportsDeveloperRole = false` needed.
- **`reasoning_effort`**: Accepted — no `compat.supportsReasoningEffort = false` needed.
- **Reasoning model mapping**: Works natively via pi's `--model ...:<thinking>` suffix (e.g. `litellm/glm-latest:max`), no special config required.

## Usage

```bash
# Interactive (prompts for JUSPAY_API_KEY if not set)
nix run github:juspay/AI#pi-juspay-oneclick -- --model litellm/kimi-k3

# Reasoning model with effort tier
nix run github:juspay/AI#pi-juspay-oneclick -- --model litellm/glm-latest:max

# Merge Juspay into existing ~/.pi
nix run github:juspay/AI#pi-juspay-editable -- --model litellm/glm-latest
```
